### PR TITLE
Update the translation checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Eslint-plugin-agama-i18n changelog
+
+## 1.1.0
+
+- Allow merging strings with + operator in the translation functions (e.g.
+  `_("foo" + "bar")`). The latest GNU gettext supports that in the Javascript
+  input format.
+- Added a new `top-level-translation` check which checks for calling the
+  translation functions `_()` and `n_()` at the top level in the Javascript
+  file. That does not work because these calls are evaluated too early, before
+  the actual translations are available.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # The ESLint Plugin
 
-![NPM Version](https://img.shields.io/npm/v/eslint-plugin-agama-i18n)
+![NPM Version](https://img.shields.io/npm/v/@agama-project/eslint-plugin-agama-i18n)
 [![CI](https://github.com/agama-project/eslint-plugin-agama-i18n/actions/workflows/ci.yml/badge.svg)](https://github.com/agama-project/eslint-plugin-agama-i18n/actions/workflows/ci.yml)
 
-This directory contains a simple ESLint plugin which checks that only string
-literals are passed to the translation functions.
+This directory contains a simple ESLint plugin which checks for some common
+translation problems:
 
-It is closely tied to the [Agama](https://github.com/agama-project/agama) project and
-probably does not make much sense for other projects.
+- Only string literals are allowed as arguments in the translation functions (or
+  their concatenation using the `+` operator)
+- Translation functions are not allowed at the top level (they are evaluated too
+  early, before the actual translations are available)
+
+It is closely tied to the [Agama](https://github.com/agama-project/agama)
+project and probably does not make much sense for other projects.
 
 ## Installation
 
@@ -32,6 +37,7 @@ export default [
   {
     rules: {
       "agama-i18n/string-literals": "error",
+      "agama-i18n/top-level-translation": "error"
     }
   }
 ];
@@ -52,11 +58,23 @@ const sz = getSize();
 return <span>{_(sz)}</span>;
 ```
 
+## Testing changes during development
+
+To test new changes locally during development install the plugin into an Agama
+checkout using command `npm install ../../eslint-plugin-agama-i18n/` (the path
+should point to checkout of this plugin).
+
+This creates a symlink pointing to the plugin directory so it will always use
+the latest files from the local plugin, that is very convenient during
+development.
+
 ## Publishing new version
 
-The NPM package is automatically published by a GitHub Action when a version tag is created.
+The NPM package is automatically published by a GitHub Action when a version tag
+is created.
 
-To create a new tag update the version in `package.json` and run the `npm run tag` command.
+To create a new tag update the version in `package.json` and run the `npm run
+tag` command.
 
 ## Links
 

--- a/eslint-plugin-agama-i18n.js
+++ b/eslint-plugin-agama-i18n.js
@@ -4,10 +4,12 @@
  */
 
 const stringLiteralsRule = require("./string-literals");
+const topLevelRule = require("./top-level-translation");
 
 module.exports = {
   rules: {
     // name of the rule
-    "string-literals": stringLiteralsRule
-  }
+    "string-literals": stringLiteralsRule,
+    "top-level-translation": topLevelRule,
+  },
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "main": "eslint-plugin-agama-i18n.js",
   "scripts": {
-    "test": "node string-literals.test.js && node top-level-translation.test.js",
+    "test": "find . -name '*.test.js' -exec node \\{\\} \\;",
     "tag": "VERSION=`jq -r .version package.json` && git tag -s -m \"Version $VERSION\" v$VERSION && git push origin v$VERSION"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agama-project/eslint-plugin-agama-i18n",
-  "version": "1.0.0",
-  "description": "A simple ESLint plugin which checks that only string literals are passed to the translation functions",
+  "version": "1.1.0",
+  "description": "A simple ESLint plugin which checks usage of the translation functions",
   "homepage": "https://github.com/agama-project/eslint-plugin-agama-i18n",
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "main": "eslint-plugin-agama-i18n.js",
   "scripts": {
-    "test": "node string-literals.test.js",
+    "test": "node string-literals.test.js && node top-level-translation.test.js",
     "tag": "VERSION=`jq -r .version package.json` && git tag -s -m \"Version $VERSION\" v$VERSION && git push origin v$VERSION"
   },
   "peerDependencies": {

--- a/string-literals.js
+++ b/string-literals.js
@@ -8,7 +8,8 @@ const translations = ["_", "n_", "N_", "Nn_"];
 // names of the plural translation functions
 const plurals = ["n_", "Nn_"];
 
-const errorMsgLiteral = "Use a string literal argument in the translation functions";
+const errorMsgLiteral =
+  "Use a string literal argument in the translation functions";
 const errorMsgMissing = "Missing argument";
 
 /**
@@ -19,7 +20,16 @@ const errorMsgMissing = "Missing argument";
 function isStringLiteral(node) {
   if (!node) return false;
 
-  return node.type === "Literal" && (typeof node.value === "string");
+  // plain string literal
+  if (node.type === "Literal" && typeof node.value === "string") return true;
+
+  // or a binary expression with "+" operator and string literals or a nested "+" operator
+  return (
+    node.type === "BinaryExpression" &&
+    node.operator === "+" &&
+    isStringLiteral(node.left) &&
+    isStringLiteral(node.right)
+  );
 }
 
 /**
@@ -45,7 +55,8 @@ module.exports = {
   meta: {
     type: "problem",
     docs: {
-      description: "Check that only string literals are passed to the translation functions.",
+      description:
+        "Check that only string literals are passed to the translation functions.",
     },
   },
   create: function (context) {
@@ -62,7 +73,7 @@ module.exports = {
         if (plurals.includes(node.callee.name)) {
           checkNode(node.arguments[1], node, context);
         }
-      }
+      },
     };
-  }
+  },
 };

--- a/string-literals.test.js
+++ b/string-literals.test.js
@@ -8,37 +8,41 @@ const stringLiteralsRule = require("./string-literals");
 
 const ruleTester = new RuleTester();
 
-ruleTester.run(
-  "string-literals",
-  stringLiteralsRule,
-  {
-    // valid code examples, these should pass
-    valid: [
-      { code: "_(\"foo\")" },
-      { code: "_('foo')" },
-      { code: "n_(\"one\", \"many\", count)" },
-      { code: "n_('one', 'many', count)" },
-    ],
-    // invalid examples, these should fail
-    invalid: [
-      // string literal errors
-      { code: "_(null)", errors: 1 },
-      { code: "_(undefined)", errors: 1 },
-      { code: "_(42)", errors: 1 },
-      { code: "_(foo)", errors: 1 },
-      { code: "_(foo())", errors: 1 },
-      { code: "_(`foo`)", errors: 1 },
-      { code: "_(\"foo\" + \"bar\")", errors: 1 },
-      { code: "_('foo' + 'bar')", errors: 1 },
-      // missing argument errors
-      { code: "_()", errors: 1 },
-      { code: "n_('foo')", errors: 1 },
-      { code: "n_(\"foo\")", errors: 1 },
-      // string literal + missing argument errors
-      { code: "n_(foo)", errors: 2 },
-      // string literal error twice
-      { code: "n_(foo, bar)", errors: 2 },
-      { code: "Nn_(foo, bar)", errors: 2 },
-    ],
-  }
-);
+ruleTester.run("string-literals", stringLiteralsRule, {
+  // valid code examples, these should pass
+  valid: [
+    { code: '_("foo")' },
+    { code: "_('foo')" },
+    { code: 'n_("one", "many", count)' },
+    { code: "n_('one', 'many', count)" },
+    // concatenating multiple string literals is allowed
+    { code: '_("foo" + "bar")' },
+    { code: '_("foo" + "bar" + "baz")' },
+    { code: '_("foo" + "bar" + "baz" + "qux")' },
+    { code: 'n_("foo" + "bar", "baz" + "qux", count)' },
+  ],
+  // invalid examples, these should fail
+  invalid: [
+    // string literal errors
+    { code: "_(null)", errors: 1 },
+    { code: "_(undefined)", errors: 1 },
+    { code: "_(42)", errors: 1 },
+    { code: "_(foo)", errors: 1 },
+    { code: "_(foo())", errors: 1 },
+    { code: "_(`foo`)", errors: 1 },
+    // missing argument errors
+    { code: "_()", errors: 1 },
+    { code: "n_('foo')", errors: 1 },
+    { code: 'n_("foo")', errors: 1 },
+    // string literal + missing argument errors
+    { code: "n_(foo)", errors: 2 },
+    // string literal error twice
+    { code: "n_(foo, bar)", errors: 2 },
+    { code: "Nn_(foo, bar)", errors: 2 },
+    // concatenating is allowed only with string literals
+    { code: "_(42 + 42)", errors: 1 },
+    { code: '_("42" + 42)', errors: 1 },
+    { code: '_(42 + "42")', errors: 1 },
+    { code: '_(foo.toString() + "42")', errors: 1 },
+  ],
+});

--- a/top-level-translation.js
+++ b/top-level-translation.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * Check that the translation functions are not used at the top level in the
+ * source code.
+ */
+
+// names of all translation functions which should not be used at the top level,
+// the "N_()", "Nn_()" actually do not translate the texts so they are allowed
+const translations = ["_", "n_"];
+
+// define the eslint rule
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Check that the translation functions are not used at the top level.",
+    },
+  },
+  create: function (context) {
+    // the current function level, 0 = toplevel global context
+    let level = 0;
+
+    function enterFunction() {
+      // increase nesting
+      level += 1;
+    }
+
+    function leaveFunction() {
+      // decrease nesting
+      level -= 1;
+    }
+
+    function callFunction(node) {
+      // not a translation function, skip it
+      if (!translations.includes(node.callee.name)) return;
+
+      // check the current level
+      if (level === 0) {
+        context.report(
+          node,
+          `${node.callee.name}() does not work correctly at the toplevel (use N${node.callee.name}() or move it into a function)`
+        );
+      }
+    }
+
+    return {
+      // entering a function definition
+      FunctionDeclaration: enterFunction,
+      FunctionExpression: enterFunction,
+      ArrowFunctionExpression: enterFunction,
+      // leaving a function definition
+      "FunctionDeclaration:exit": leaveFunction,
+      "FunctionExpression:exit": leaveFunction,
+      "ArrowFunctionExpression:exit": leaveFunction,
+      // calling a function
+      CallExpression: callFunction,
+    };
+  },
+};

--- a/top-level-translation.test.js
+++ b/top-level-translation.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ * Unit tests for the opt level translations check.
+ */
+
+const { RuleTester } = require("eslint");
+const topLevelRule = require("./top-level-translation");
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("top-level-translation", topLevelRule, {
+  // valid code examples, these should pass
+  valid: [
+    // these can be used at the top level
+    { code: 'const foo = N_("foo")' },
+    { code: 'const foo = Nn_("foo", "bar", count)' },
+    // these can be used in a function body
+    // named function
+    { code: 'function foo() {const foo = _("foo");}' },
+    // anonymous function
+    { code: 'const foo = function () {const foo = _("foo");}' },
+    // arrow function
+    { code: '() => {const foo = _("foo");}' },
+    // nested arrow function
+    { code: '() => () => { const foo = _("foo");}' },
+  ],
+  // invalid examples, these should fail
+  invalid: [
+    // these cannot be used at the top level
+    { code: 'const foo = _("foo")', errors: 1 },
+    { code: 'const foo = n_("foo", "bar", count)', errors: 1 },
+    // top level after nested call
+    {
+      code: '() => () => { const foo = _("foo");}; const foo = n_("foo", "bar", count)',
+      errors: 1,
+    },
+  ],
+});


### PR DESCRIPTION
- Allow _("foo" + "bar), that is supported by the latest GNU gettext
- Do not allow top level translation calls, that does not work as expected

<details>
<summary>This is what the new check reports in the SLE-16 branch</summary>

```
> npm run eslint

> eslint
> eslint src/

/home/lslezak/devel/git/agama-project/agama/web/src/components/network/WifiConnectionForm.tsx
  43:27  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  45:30  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation

/home/lslezak/devel/git/agama-project/agama/web/src/components/software/SoftwarePage.tsx
  99:18  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation

/home/lslezak/devel/git/agama-project/agama/web/src/components/storage/dasd/DASDTable.tsx
  427:11  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  434:11  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  440:11  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  446:11  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  454:11  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  465:11  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  471:11  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation

/home/lslezak/devel/git/agama-project/agama/web/src/components/storage/dasd/FormatFilter.tsx
  43:8  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  44:8  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  45:7  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation

/home/lslezak/devel/git/agama-project/agama/web/src/components/storage/dasd/StatusFilter.tsx
  42:8   error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  43:11  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  44:14  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  45:12  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation

/home/lslezak/devel/git/agama-project/agama/web/src/components/storage/iscsi/NodeStartupOptions.js
  26:20  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  27:20  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation
  28:23  error  _() does not work correctly at the toplevel (use N_() or move it into a function)  agama-i18n/top-level-translation

✖ 20 problems (20 errors, 0 warnings)
```

</details>