### PR TITLE
Track variables used in _()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Eslint-plugin-agama-i18n changelog
 
+## 1.2.0
+
+- Track the global constants initialized with `N_()` so not using a string
+  literal in this construct is not reported as an error:
+
+  ```js
+  const foo = N_("foo");
+  () => _(foo);
+  ```
+
 ## 1.1.0
 
 - Allow merging strings with + operator in the translation functions (e.g.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agama-project/eslint-plugin-agama-i18n",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A simple ESLint plugin which checks usage of the translation functions",
   "homepage": "https://github.com/agama-project/eslint-plugin-agama-i18n",
   "repository": {

--- a/string-literals.test.js
+++ b/string-literals.test.js
@@ -20,6 +20,12 @@ ruleTester.run("string-literals", stringLiteralsRule, {
     { code: '_("foo" + "bar" + "baz")' },
     { code: '_("foo" + "bar" + "baz" + "qux")' },
     { code: 'n_("foo" + "bar", "baz" + "qux", count)' },
+    // using a top level variable initialized with N_()
+    { code: 'const foo = N_("foo"); () => _(foo)' },
+    { code: "const foo = N_('foo'); () => _(foo)" },
+    {
+      code: 'const foo = N_("foo"); const bar = N_("bar"); () => _(foo) + _(bar)',
+    },
   ],
   // invalid examples, these should fail
   invalid: [
@@ -44,5 +50,13 @@ ruleTester.run("string-literals", stringLiteralsRule, {
     { code: '_("42" + 42)', errors: 1 },
     { code: '_(42 + "42")', errors: 1 },
     { code: '_(foo.toString() + "42")', errors: 1 },
+    // different variable
+    { code: 'const foo = N_("foo"); () => _(bar)', errors: 1 },
+    // initialized using an unknown function
+    { code: 'const foo = foo("foo"); () => _(bar)', errors: 1 },
+    // N_() cannot be used again
+    { code: 'const foo = N_("foo"); () => N_(bar)', errors: 1 },
+    // not at top level (use the _() function directly)
+    { code: '() => {const foo = N_("foo"); _(foo)}', errors: 1 },
   ],
 });


### PR DESCRIPTION
The string literal check verifies that only string literals are used in translation functions because variables do not work properly:

```js
const foo = "foo";
_(foo);
```

This does not work as `xgettext` cannot extract the text into the POT file.

However, there is one valid use case and that is using `N_()` function and then  `_()` later. Currently it has to be explicitly disabled so it does not complain:

```js
const foo = N_("foo");
/* eslint-disable agama-i18n/string-literals */
() => _(foo);
```

With the fix this explicit disabling is not needed as the check can detect that the variable `foo` was initialized with `N_()` call so that usage is correct.

### Notes

- It can handle only this simple case, using `N_()` is a nested object or structure is not supported, initializing in a nested function is not supported as well.