### PR TITLE
Added multiple space rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Eslint-plugin-agama-i18n changelog
 
+## 1.3.0
+
+- Check multiple white space characters in translated messages.
+
+Example:
+
+```js
+{
+  {
+    {
+      const message = _("Some very long message \
+        which spans across multiple lines.");
+    }
+  }
+}
+```
+
+The problem is that the indentation on the second line is actually included in
+the message text. The HTML collapses multiple spaces to a single space when
+rendered in a browser so in the end it is not a visible problem for users.
+
+But it might be confusing for the translators, they will see text "Some very
+long message &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; which spans across multiple
+lines." to translate and they might be wondering if the the extra space
+characters need to be kept or not.
+
+The problem can be fixed in two ways:
+
+1. Remove the indentation so the text starts on the beginning of the next line.
+   But that visually breaks the code and that does not look nice.
+2. Split the parts into separate substrings and merge them with the `+`
+   operator. The latest GNU gettext correctly concatenates the string parts into
+   a single translatable text when generating the POT file so it is a
+   transparent operation for the translators.
+
 ## 1.2.0
 
 - Track the global constants initialized with `N_()` so not using a string

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ translation problems:
   their concatenation using the `+` operator)
 - Translation functions are not allowed at the top level (they are evaluated too
   early, before the actual translations are available)
+- The text should not contain multiple white space characters in a sequence (in
+  HTML they are collapsed to a single space anyway and multiple spaces might be
+  confusing for translators.)
 
 It is closely tied to the [Agama](https://github.com/agama-project/agama)
 project and probably does not make much sense for other projects.
@@ -37,7 +40,8 @@ export default [
   {
     rules: {
       "agama-i18n/string-literals": "error",
-      "agama-i18n/top-level-translation": "error"
+      "agama-i18n/top-level-translation": "error",
+      "agama-i18n/multiple-space": "error"
     }
   }
 ];

--- a/eslint-plugin-agama-i18n.js
+++ b/eslint-plugin-agama-i18n.js
@@ -5,11 +5,13 @@
 
 const stringLiteralsRule = require("./string-literals");
 const topLevelRule = require("./top-level-translation");
+const multipleSpaceRule = require("./multiple-space");
 
 module.exports = {
   rules: {
     // name of the rule
     "string-literals": stringLiteralsRule,
     "top-level-translation": topLevelRule,
+    "multiple-space": multipleSpaceRule,
   },
 };

--- a/multiple-space.js
+++ b/multiple-space.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ */
+
+// names of all translation functions
+const translations = ["_", "n_", "N_", "Nn_"];
+// names of the plural translation functions
+const plurals = ["n_", "Nn_"];
+
+const errorMsgSpaces =
+  "Do not use multiple spaces in sequence, they are ignored in HTML";
+
+/**
+ * Check whether the AST node is a string literal with multiple spaces
+ * @param {Object} node the node to check
+ * @param {Object} context the context for reporting an error
+ */
+function checkNode(node, context) {
+  if (
+    node &&
+    node.type === "Literal" &&
+    typeof node.value === "string" &&
+    node.value.match(/\s{2,}/)
+  )
+    context.report(node, errorMsgSpaces);
+}
+
+// define the eslint rule
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Check that string literals do not contain multiple whitespace characters in sequence.",
+    },
+  },
+  create: function (context) {
+    return {
+      // callback for handling function calls
+      CallExpression(node) {
+        // not a translation function, skip it
+        if (!translations.includes(node.callee.name)) return;
+
+        // check the first argument
+        checkNode(node.arguments[0], context);
+
+        // check also the second argument for the plural forms
+        if (plurals.includes(node.callee.name)) {
+          checkNode(node.arguments[1], context);
+        }
+      },
+    };
+  },
+};

--- a/multiple-space.test.js
+++ b/multiple-space.test.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) [2025] SUSE LLC
+ *
+ */
+
+const { RuleTester } = require("eslint");
+const multipleSpaceRule = require("./multiple-space");
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("multiple-space", multipleSpaceRule, {
+  // valid code examples, these should pass
+  valid: [
+    { code: '_("f o\to")' },
+    { code: "_(' f o\to ')" },
+    { code: 'n_("one", "m a n y", count)' },
+    { code: "n_('o n e', 'many', count)" },
+  ],
+  // invalid examples, these should fail
+  invalid: [
+    // double space
+    { code: "_('f  o  o')", errors: 1 },
+    { code: '_("f  o  o")', errors: 1 },
+    { code: 'n_("one", "m  a  n  y", count)', errors: 1  },
+    { code: 'n_("o  n  e", "many", count)', errors: 1  },
+    // double tabs
+    { code: "_('f\t\to\t\to')", errors: 1 },
+    // mixed space + tab
+    { code: "_('f \too')", errors: 1 },
+    { code: "_('f\t oo')", errors: 1 },
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agama-project/eslint-plugin-agama-i18n",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A simple ESLint plugin which checks usage of the translation functions",
   "homepage": "https://github.com/agama-project/eslint-plugin-agama-i18n",
   "repository": {


### PR DESCRIPTION
## Problem

- Some translatable texts in Agama contain indentation spaces, like [here](https://github.com/agama-project/agama/blob/87a04f1769e5d83439f7b1298fc486908ef511da/web/src/components/storage/EncryptionSection.tsx#L50-L51).

Example:

```js
{
  {
    {
      const message = _("Some very long message \
        which spans across multiple lines.");
    }
  }
}
```

The problem is that the indentation on the second line is actually included in the message text. The HTML collapses multiple spaces to a single space when rendered in a browser so in the end it is not a visible problem for users.

But it might be confusing for the translators, they will see text "Some very long message &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; which spans across multiple lines." to translate and they might be wondering if the the extra space characters need to be kept or not. I got this question on the IRC channel.

Let's add a new check to avoid this kind of problems.