### PR TITLE
Update Nodejs version in CI, update package-lock.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install NPM packages

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish the NPM package

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
-  "name": "eslint-plugin-agama-i18n",
-  "version": "0.1.1",
+  "name": "@agama-project/eslint-plugin-agama-i18n",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "eslint-plugin-agama-i18n",
-      "version": "0.1.1",
+      "name": "@agama-project/eslint-plugin-agama-i18n",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^9.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {


### PR DESCRIPTION
## Improvements

Tis PR contains two small improvements:

- Use Nodejs v22 in CI, the old v18 is out of support for more than half a year and SLES16/Leap16 uses v22 as well
- Updated `package-lock.json` file, updated automatically after running `npm install`